### PR TITLE
docs: add github profile links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ you.
 The ``molflux`` package has been developed by researchers and engineers at Exscientia
 
 * Alan Bilsland
-* Julia Buhmann
-* Ward Haddadin
+* [Julia Buhmann](https://github.com/juliabuhmann)
+* [Ward Haddadin](https://github.com/wardhaddadin1)
 * Jonathan Harrison
 * Dom Miketa
 * Emil Nichita
 * Stefanie Speichert
 * Hagen Triendl
-* Alvise Vianello
+* [Alvise Vianello](https://github.com/amv213)


### PR DESCRIPTION
A very small PR to link out to our github profiles in the README ❤️ 

I have left out others that have not commited yet to this public version of the repo so that they can do this too individually as a trick to get registered by github as having contributed to the project